### PR TITLE
Prevent issues with css selectors containing parentheses

### DIFF
--- a/lib/cssjanus.js
+++ b/lib/cssjanus.js
@@ -48,7 +48,7 @@ function CSSJanus() {
 		fourNotationColorPropsPattern = '(-color\\s*:\\s*)',
 		colorPattern = '(#?' + nmcharPattern + '+)',
 		urlCharsPattern = '(?:' + urlSpecialCharsPattern + '|' + nonAsciiPattern + '|' + escapePattern + ')*',
-		lookAheadNotOpenBracePattern = '(?!(' + nmcharPattern + '|\\r?\\n|\\s|#|\\:|\\.|\\,|\\+|>)*?{)',
+		lookAheadNotOpenBracePattern = '(?!(' + nmcharPattern + '|\\r?\\n|\\s|#|\\:|\\.|\\,|\\+|>|\\(|\\))*?{)',
 		lookAheadNotClosingParenPattern = '(?!' + urlCharsPattern + '?' + validAfterUriCharsPattern + '\\))',
 		lookAheadForClosingParenPattern = '(?=' + urlCharsPattern + '?' + validAfterUriCharsPattern + '\\))',
 		// Regular expressions


### PR DESCRIPTION
See https://code.google.com/p/cssjanus/issues/detail?id=22

This has already been fixed in MediaWiki php port - https://doc.wikimedia.org/mediawiki-core/master/php/html/CSSJanus_8php_source.html
