### PR TITLE
Extend noflip regex to allow '/*!'

### DIFF
--- a/lib/cssjanus.js
+++ b/lib/cssjanus.js
@@ -36,7 +36,7 @@ function CSSJanus() {
 		validAfterUriCharsPattern = '[\'"]?\\s*',
 		nonLetterPattern = '(^|[^a-zA-Z])',
 		charsWithinSelectorPattern = '[^\\}]*?',
-		noFlipPattern = '\\/\\*\\s*@noflip\\s*\\*\\/',
+		noFlipPattern = '\\/\\*\\!?\\s*@noflip\\s*\\*\\/',
 		commentPattern = '\\/\\*[^*]*\\*+([^\\/*][^*]*\\*+)*\\/',
 		escapePattern = '(?:' + unicodePattern + '|\\\\[^\\r\\n\\f0-9a-f])',
 		nmstartPattern = '(?:[_a-z]|' + nonAsciiPattern + '|' + escapePattern + ')',


### PR DESCRIPTION
I'm using Less to generate my css files, before converting them to RTL. I need to use `/*! @noflip */` to force less to keep the comment.
The current regex does not pick this as noflip.
