### PR TITLE
Remove documentation of non-existent parameters

### DIFF
--- a/lib/cssjanus.js
+++ b/lib/cssjanus.js
@@ -13,8 +13,6 @@
  * 
  * @class
  * @constructor
- * @param {RegExp} regex Regular expression whose matches to replace by a token
- * @param {String} token Placeholder text
  */
 function CSSJanus() {
 


### PR DESCRIPTION
CSSJanus() takes no arguments
