### PR TITLE
Refactor, work with cursor nesw, comments as whitespace, bugfix

### DIFF
--- a/test/data.json
+++ b/test/data.json
@@ -139,6 +139,10 @@
 			[
 				"body{\n direction: rtl\n}",
 				"body{\n direction: ltr\n}"
+			],
+			[
+				"body{ /* Comments */ direction/*inside*/:/*the*/ rtl/*CSS*/;/*.*/ }",
+				"body{ /* Comments */ direction/*inside*/:/*the*/ ltr/*CSS*/;/*.*/ }"
 			]
 		]
 	},
@@ -210,6 +214,14 @@
 			[
 				".foo { cursor: nw-resize; }",
 				".foo { cursor: ne-resize; }"
+			],
+			[
+				".foo { cursor: nesw-resize; }",
+				".foo { cursor: nwse-resize; }"
+			],
+			[
+				".foo { cursor /* Test */ : /* comments */ w-resize /* . */; }",
+				".foo { cursor /* Test */ : /* comments */ e-resize /* . */; }"
 			]
 		]
 	},
@@ -218,6 +230,10 @@
 			[
 				".foo { text-align: left; }",
 				".foo { text-align: right; }"
+			],
+			[
+				".foo { text-align-last: left; }",
+				".foo { text-align-last: right; }"
 			]
 		]
 	},
@@ -672,11 +688,20 @@
 				"url('http://www.blogger.com/img/triangle_ltr.gif'\t)"
 			],
 			[
+				"background: url(/foo/filtr.png)"
+			],
+			[
+				"background: url(/foo/ltrly_metaphorical.png)"
+			],
+			[
 				"background: url(/foo/bar.right.png)",
 				"background: url(/foo/bar.left.png)"
 			],
 			[
 				"background: url(/foo/bright.png)"
+			],
+			[
+				"background: url(/foo/smurf-rights.png)"
 			],
 			[
 				"background: url(/foo/bar-ltr.png)",
@@ -786,6 +811,27 @@
 			[
 				".foo { float: left; float: right; float: left; }",
 				".foo { float: right; float: left; float: right; }"
+			]
+		]
+	},
+	"work with different capitalizations": {
+		"roundtrip": false,
+		"cases": [
+			[
+				".foo { FlOaT: LeFt; }",
+				".foo { FlOaT: right; }"
+			],
+			[
+				".foo { Direction: LtR; }",
+				".foo { Direction: rtl; }"
+			],
+			[
+				".foo { Cursor: NeSw-resize; }",
+				".foo { Cursor: nwse-resize; }"
+			],
+			[
+				".foo { Padding-Left: 1px; }",
+				".foo { Padding-right: 1px; }"
 			]
 		]
 	},


### PR DESCRIPTION
Per [Krinkle's suggestion](https://github.com/cssjanus/cssjanus/pull/36#issuecomment-364786710) on splitting up the change for TTB support (#36) into smaller changes. Some refactoring, added support for `cursor: nesw-resize;` some support for `/* comments */` within CSS statements (eg `direction /* */ : /* */ ltr /* */;`), and fixed a bug with URLs accepting keywords with immediately-following letters (see tests in "flip URLs when url transforms are on").