### PR TITLE
Fix: Prevent flipping percentages in CSS color functions

### DIFF
--- a/src/cssjanus.js
+++ b/src/cssjanus.js
@@ -182,12 +182,17 @@ function CSSJanus() {
 	 * @return {string} Inverted property
 	 */
 	function calculateNewBackgroundPosition( match, pre, value ) {
-		var idx, len;
+		// Check if inside a known color function
+		var lowerPre = pre.toLowerCase();
+		if (/(?:rgb|rgba|hsl|hsla|hwb|lab|lch|oklab|oklch|color|color-mix|linear-gradient)\(/.test(lowerPre)) {
+			// Do not flip if inside a color function
+			return pre + value;
+		}
+
 		if ( value.slice( -1 ) === '%' ) {
-			idx = value.indexOf( '.' );
+			var idx = value.indexOf( '.' );
 			if ( idx !== -1 ) {
-				// Two off, one for the "%" at the end, one for the dot itself
-				len = value.length - idx - 2;
+				var len = value.length - idx - 2;
 				value = 100 - parseFloat( value );
 				value = value.toFixed( len ) + '%';
 			} else {


### PR DESCRIPTION
This PR updates the calculateNewBackgroundPosition function to skip flipping percentages when they appear inside CSS color functions (e.g., hsl(), hsla(), color(), lab(), etc.). This ensures that saturation/lightness and other non-positional percentages remain unchanged, fixing [issue #92].

Original Code:
<img width="706" alt="Screenshot 2024-12-11 at 10 05 24" src="https://github.com/user-attachments/assets/413405d2-ee68-4949-a73b-a5f21a8bae4a">

Fixed Code: 
<img width="828" alt="Screenshot 2024-12-11 at 10 04 28" src="https://github.com/user-attachments/assets/bcdb5072-4f7c-4c1e-bf2a-9877b9ad039a">
